### PR TITLE
fix: Add INTERNET permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"


### PR DESCRIPTION
This commit adds the INTERNET permission to the AndroidManifest.xml file. This is necessary to allow the app to load images from the internet using the Coil library. This fixes a crash that occurred when the app tried to access the network without the required permission.