### PR TITLE
feat: Redesign dashboard with grid layout, search, and filters

### DIFF
--- a/app/src/main/java/com/example/my_jules_test_app/ui/components/ProductList.kt
+++ b/app/src/main/java/com/example/my_jules_test_app/ui/components/ProductList.kt
@@ -1,7 +1,8 @@
 package com.example.my_jules_test_app.ui.components
 
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -17,7 +18,7 @@ fun ProductList(
 ) {
     val cartItems by cartViewModel.cartItems.collectAsState()
 
-    LazyColumn {
+    LazyVerticalGrid(columns = GridCells.Fixed(2)) {
         items(products) { product ->
             ProductListItem(
                 product = product,

--- a/app/src/main/java/com/example/my_jules_test_app/ui/components/ProductListItem.kt
+++ b/app/src/main/java/com/example/my_jules_test_app/ui/components/ProductListItem.kt
@@ -1,5 +1,6 @@
 package com.example.my_jules_test_app.ui.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -9,6 +10,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -23,38 +25,41 @@ fun ProductListItem(
 ) {
     Card(
         modifier = Modifier
-            .fillMaxWidth()
             .padding(8.dp)
             .clickable { onItemClick() },
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        border = BorderStroke(1.dp, Color.LightGray)
     ) {
         Column(
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             AsyncImage(
                 model = "file:///android_asset/${product.imageName}",
                 contentDescription = product.name,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(150.dp),
+                    .height(120.dp),
                 contentScale = ContentScale.Crop
             )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(text = product.name, style = MaterialTheme.typography.headlineSmall)
-            Text(text = "₹${product.price}", style = MaterialTheme.typography.bodyLarge)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = product.name, style = MaterialTheme.typography.titleMedium)
+            Text(text = "₹${product.price}", style = MaterialTheme.typography.bodyMedium)
             Spacer(modifier = Modifier.height(8.dp))
 
             if (quantity == 0) {
-                Button(
+                OutlinedButton(
                     onClick = { onQuantityChange(1) },
-                    modifier = Modifier.align(Alignment.End)
+                    modifier = Modifier.fillMaxWidth()
                 ) {
+                    Icon(imageVector = Icons.Default.Add, contentDescription = "Add", modifier = Modifier.size(16.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
                     Text(text = "ADD")
                 }
             } else {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.End,
+                    horizontalArrangement = Arrangement.Center,
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     IconButton(onClick = { onQuantityChange(quantity - 1) }) {

--- a/app/src/main/java/com/example/my_jules_test_app/ui/screen/DashboardScreen.kt
+++ b/app/src/main/java/com/example/my_jules_test_app/ui/screen/DashboardScreen.kt
@@ -1,74 +1,66 @@
 package com.example.my_jules_test_app.ui.screen
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import com.example.my_jules_test_app.data.model.ProductType
 import com.example.my_jules_test_app.ui.components.ProductList
 import com.example.my_jules_test_app.ui.viewmodel.CartViewModel
 import com.example.my_jules_test_app.ui.viewmodel.DashboardViewModel
-import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DashboardScreen(
     navController: NavController,
     dashboardViewModel: DashboardViewModel = viewModel(),
     cartViewModel: CartViewModel = viewModel()
 ) {
-    val pagerState = rememberPagerState(pageCount = { 2 })
-    val scope = rememberCoroutineScope()
-    val tabTitles = listOf("Vegetables", "Fruits")
     val products by dashboardViewModel.products.collectAsState()
+    val searchQuery by dashboardViewModel.searchQuery.collectAsState()
+    val selectedCategory by dashboardViewModel.selectedCategory.collectAsState()
 
     Column(modifier = Modifier.fillMaxSize()) {
-        TabRow(selectedTabIndex = pagerState.currentPage) {
-            tabTitles.forEachIndexed { index, title ->
-                Tab(
-                    selected = pagerState.currentPage == index,
-                    onClick = {
-                        scope.launch {
-                            pagerState.animateScrollToPage(index)
-                        }
-                    },
-                    text = { Text(text = title) }
-                )
-            }
+        TextField(
+            value = searchQuery,
+            onValueChange = { dashboardViewModel.onSearchQueryChange(it) },
+            label = { Text("Search") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilterChip(
+                selected = selectedCategory == "All",
+                onClick = { dashboardViewModel.onCategorySelected("All") },
+                label = { Text("All") }
+            )
+            FilterChip(
+                selected = selectedCategory == "Vegetables",
+                onClick = { dashboardViewModel.onCategorySelected("Vegetables") },
+                label = { Text("Vegetables") }
+            )
+            FilterChip(
+                selected = selectedCategory == "Fruits",
+                onClick = { dashboardViewModel.onCategorySelected("Fruits") },
+                label = { Text("Fruits") }
+            )
         }
 
-        HorizontalPager(state = pagerState) { page ->
-            when (page) {
-                0 -> {
-                    ProductList(
-                        products = products.filter { it.type == ProductType.VEGETABLE },
-                        onItemClick = { product ->
-                            navController.navigate("productDetail/${product.id}")
-                        },
-                        cartViewModel = cartViewModel
-                    )
-                }
-                1 -> {
-                    ProductList(
-                        products = products.filter { it.type == ProductType.FRUIT },
-                        onItemClick = { product ->
-                            navController.navigate("productDetail/${product.id}")
-                        },
-                        cartViewModel = cartViewModel
-                    )
-                }
-            }
-        }
+        ProductList(
+            products = products,
+            onItemClick = { product ->
+                navController.navigate("productDetail/${product.id}")
+            },
+            cartViewModel = cartViewModel
+        )
     }
 }


### PR DESCRIPTION
This commit redesigns the dashboard to match the user's provided screenshot.

- Replaced the tabbed layout with a single screen that displays all products in a 2-column grid.
- Redesigned the product cards to be more compact and visually appealing.
- Added a search bar and category filter chips to allow users to easily find products.
- Implemented the logic for searching and filtering the product list.